### PR TITLE
Chore/add build ci

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# Basic dockerignore file to ignore certain paths in the docker builds
+# This is handy to stop secrets/env files/local builds making it into the Production ones.
+
+**/dist
+*.env

--- a/.github/healthchecker.sh
+++ b/.github/healthchecker.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Helper function to run basic http integrity checks on an endpoint, call it like:
+# healthchecker.sh 15 user:pass http://localhost:8080. Stages results in /tmp/url-responses.
+
+# Where:
+# $1: seconds to run the check for
+# $2: basic auth header
+# $3: endpoint to validate for 200 response
+
+endpoint_healthcheck() {
+
+    for url in $URLS
+    do
+
+        LINK_HTTP_CODE=$(curl -u $AUTH_HEADERS -I -s -m 5 -o /dev/null -w "%{http_code}" $url || echo "500" )
+        echo "INFO: $LINK_HTTP_CODE found for $url"
+
+        if [ "$LINK_HTTP_CODE" -eq 200 ]
+        then
+            echo "0" >> /tmp/url-responses
+        else
+            echo "1" >> /tmp/url-responses
+        fi
+
+    done
+
+    FAILURE_NUMBER=$(cat /tmp/url-responses | { grep "1" | wc -l | xargs || true; } )
+    echo "INFO: FAILURE_NUMBER found to be $FAILURE_NUMBER"
+
+    rm /tmp/url-responses
+
+    [[ $FAILURE_NUMBER == 0 ]] && echo "SUCCESS: All endpoints returned 200" && exit 0 || true
+}
+
+main() {
+
+    echo "INFO: Running url checks for $SECS_TO_CHECK seconds."
+
+    COUNT=0
+
+    while [ "$COUNT" -lt $SECS_TO_CHECK ]
+    do
+        endpoint_healthcheck
+        COUNT=$((COUNT+1))
+        sleep 1
+    done
+
+    echo "ERROR: Endpoints did not return 200"
+    exit 1
+
+}
+
+export SECS_TO_CHECK=$1  # < 60 (minutes) >
+export AUTH_HEADERS=$2   # < automation-user:automation-user >
+export URLS="${@:3}"     # < List of URLs >
+
+main $SECS_TO_CHECK $URLS

--- a/.github/workflows/core-build.yml
+++ b/.github/workflows/core-build.yml
@@ -1,0 +1,30 @@
+# This workflow will build the two projects
+
+name: core-build
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Start mongodb Sidecar
+      run: docker-compose -f "./local-development/docker-compose-mongo.yml" up -d
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.19
+
+    - name: Build
+      run: make build
+
+    - name: Test
+      run: go test -v ./...

--- a/.github/workflows/core-build.yml
+++ b/.github/workflows/core-build.yml
@@ -9,22 +9,29 @@ on:
     branches: [ "main" ]
 
 jobs:
-
-  build:
+  build-fe:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+      - name: Make build FE
+        run: make build-fe
+      - name: Make validate FE (checks the application's integrity at a basic level)
+        run: make validate-fe
 
-    - name: Start mongodb Sidecar
-      run: docker-compose -f "./local-development/docker-compose-mongo.yml" up -d
+  build-be:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Make build BE
+        run: make build-be
+      - name: Make validate BE (checks the application's integrity at a basic level)
+        run: make validate-be
 
-    - name: Set up Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.19
+  # This will be developed out to include the deployment of the images
+  deploy-apps:
+    needs: [build-fe, build-be]
+    runs-on: ubuntu-latest
 
-    - name: Build
-      run: make build
-
-    - name: Test
-      run: go test -v ./...
+    steps:
+      - name: Use Images Here
+        run: echo "Using images from previous build step here"

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ build-fe:
 
 validate-be:
 	docker compose -f ./local-development/docker-compose-be.yml --env-file ./local-development/development.env up -d
-	.github/healthchecker.sh 15 user:pass http://0.0.0.0:3030/api/users
+	.github/healthchecker.sh 15 user:pass http://0.0.0.0:3030/api/users || docker logs local-development-si-assessment-ie3-backend-1 && exit 1
 
 validate-fe:
 	docker compose -f ./local-development/docker-compose-fe.yml --env-file ./local-development/development.env up -d
-	.github/healthchecker.sh 15 user:pass http://localhost:8080
+	.github/healthchecker.sh 15 user:pass http://localhost:8080 || docker logs local-development-si-assessment-ie3-backend-1 && exit 1

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build-fe:
 
 validate-be:
 	docker compose -f ./local-development/docker-compose-be.yml --env-file ./local-development/development.env up -d
-	.github/healthchecker.sh 15 user:pass http://localhost:3030/api/users
+	.github/healthchecker.sh 15 user:pass http://0.0.0.0:3030/api/users
 
 validate-fe:
 	docker compose -f ./local-development/docker-compose-fe.yml --env-file ./local-development/development.env up -d

--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,22 @@ SHELL = /bin/sh
 .PHONY: build, test
 default: build
 
+# There is some code duplication here that could be handled later. For now this will
+# function accordingly for quick validation
+
 deploy:
 	docker compose -f ./local-development/docker-compose-stack.yml --env-file ./local-development/development.env up
 
 build-be:
-	echo "Info: Building Backend:"
 	docker build --platform linux/amd64 -f ./backend/hosting/docker/Dockerfile -t si-assessment-ie3-backend:latest .
 
 build-fe:
-	echo "Info: Building Frontend:"
 	docker build --platform linux/amd64 -f ./frontend/hosting/docker/Dockerfile -t si-assessment-ie3-frontend:latest .
 
-fmt:
-	go fmt ./cmd/...
+validate-be:
+	docker compose -f ./local-development/docker-compose-be.yml --env-file ./local-development/development.env up -d
+	.github/healthchecker.sh 15 user:pass http://localhost:3030/api/users
+
+validate-fe:
+	docker compose -f ./local-development/docker-compose-fe.yml --env-file ./local-development/development.env up -d
+	.github/healthchecker.sh 15 user:pass http://localhost:8080

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+# Define required macros here
+SHELL = /bin/sh
+
+.PHONY: build, test
+default: build
+
+deploy:
+	docker compose -f ./local-development/docker-compose-stack.yml --env-file ./local-development/development.env up
+
+build-be:
+	echo "Info: Building Backend:"
+	docker build --platform linux/amd64 -f ./backend/hosting/docker/Dockerfile -t si-assessment-ie3-backend:latest .
+
+build-fe:
+	echo "Info: Building Frontend:"
+	docker build --platform linux/amd64 -f ./frontend/hosting/docker/Dockerfile -t si-assessment-ie3-frontend:latest .
+
+fmt:
+	go fmt ./cmd/...

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Define required macros here
-SHELL = /bin/sh
+SHELL = /bin/bash
 
 .PHONY: build, test
 default: build
@@ -18,8 +18,8 @@ build-fe:
 
 validate-be:
 	docker compose -f ./local-development/docker-compose-be.yml --env-file ./local-development/development.env up -d
-	.github/healthchecker.sh 15 user:pass http://0.0.0.0:3030/api/users || docker logs local-development-si-assessment-ie3-backend-1 && exit 1
+	.github/healthchecker.sh 120 user:pass http://localhost:3030/api/users
 
 validate-fe:
 	docker compose -f ./local-development/docker-compose-fe.yml --env-file ./local-development/development.env up -d
-	.github/healthchecker.sh 15 user:pass http://localhost:8080 || docker logs local-development-si-assessment-ie3-backend-1 && exit 1
+	.github/healthchecker.sh 15 user:pass http://localhost:8080

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Hopefully this makes it easier to follow the path I have taken. I have also outl
          - https://github.com/johnrwatson/si-assessment-ie3/pull/3
 
 2. CI (Continuous Integration): Build, Test, and Release flow:
-   - [ ] Build + Containerize the applications, with local deployment validation
+   - [X] Build + Containerize the applications, with local deployment validation
+         - Added a hosting/docker/Dockerfile into each application path and added a Makefile that allows quick validation of build, e.g. `make build-fe`. Additionally, `make deploy` immediately deploys the two tags of si-assessment-ie3-backend:latest and si-assessment-ie3-frontned:latest, which would be available locally if `make build-fe` / `make build-be` were used. The `local-development/docker-compose-stack.yml` file can be manipulated accordingly if the developer or tester wanted to check two different versions of the services together. On `make deploy` the frontend service can be reached on x and the backend service can be reached on y.
    - [ ] Initiate tests in CI
      - [ ] Lint
      - [ ] Unit Test

--- a/README.md
+++ b/README.md
@@ -29,8 +29,13 @@ Hopefully this makes it easier to follow the path I have taken. I have also outl
 
 2. CI (Continuous Integration): Build, Test, and Release flow:
    - [X] Build + Containerize the applications, with local deployment validation
-         - Added a hosting/docker/Dockerfile into each application path and added a Makefile that allows quick validation of build, e.g. `make build-fe`. Additionally, `make deploy` immediately deploys the two tags of si-assessment-ie3-backend:latest and si-assessment-ie3-frontned:latest, which would be available locally if `make build-fe` / `make build-be` were used. The `local-development/docker-compose-stack.yml` file can be manipulated accordingly if the developer or tester wanted to check two different versions of the services together. On `make deploy` the frontend service can be reached on x and the backend service can be reached on y.
-   - [ ] Initiate tests in CI
+         - Added a hosting/docker/Dockerfile into each application path and added a Makefile that allows quick validation of build, e.g. `make build-fe`. Additionally, `make deploy` immediately deploys the two tags of si-assessment-ie3-backend:latest and si-assessment-ie3-frontned:latest, which would be available locally if `make build-fe` / `make build-be` were used. The `local-development/docker-compose-stack.yml` file can be manipulated accordingly if the developer or tester wanted to check two different versions of the services together. On `make deploy` the frontend service can be reached on x and the backend service can be reached on y. Also individually added a `make validate-be` and `make validate-fe` function to quickly validate the basic http integrity of the application variant. This ensures that no code changes makes it very far without maintaining application integrity while the unit-tests and other code-validation still pass. This should stop non-compatible changes in the origin baseimage adversely affecting the compatibility with the code at a basic level.
+         - Added all the above checks in a basic CI build pipeline
+         - `frontend/src/stores/task.ts` and `frontend/src/stores/user.ts` were adjusted (poorly) to allow the backend and frontend to talk together in a docker-based environment. This could be refactored later to be an environment variable or similar.
+         - https://github.com/johnrwatson/si-assessment-ie3/pull/4
+   - [X] Initiate tests in CI
+     - [X] Application Integrity: -
+           - https://github.com/johnrwatson/si-assessment-ie3/pull/4
      - [ ] Lint
      - [ ] Unit Test
      - [ ] Security Scan

--- a/backend/README.md
+++ b/backend/README.md
@@ -8,7 +8,7 @@ It exposes a REST API that allows for creating users and tracking the tasks
 they create.
 
 It stores all of its data *in memory*, which means when the server restarts,
-any information it stores will be gone. 
+any information it stores will be gone.
 
 ## Changes to the backend
 
@@ -30,12 +30,13 @@ $ npm install
 ## Development
 
 To run the API for development, we recommend you run it in `dev` mode. This
-will restart the server automatically when you make changes to the 
+will restart the server automatically when you make changes to the
 source. (Remember that means all the data will be destroyed, so make sure you
 log out of the frontend after you make changes, or risk being out of sync.)
 
 ```
 $ npm run dev
+# By default the backend runs on port 3030
 ```
 
 To run the service without restarting it automatically, you can use:
@@ -61,7 +62,7 @@ $ npm run test:watch
 
 ## Linting
 
-We use [eslint](https://eslint.org/) to help us find problems with the code. 
+We use [eslint](https://eslint.org/) to help us find problems with the code.
 You can run the linter by:
 
 ```
@@ -111,7 +112,7 @@ Create a new user.
 {
   "id": "f62eab5e-b0f5-47de-b60b-b3cd13d883ed",
   "name": "bobo"
-} 
+}
 ```
 
 ### GET /api/users
@@ -129,7 +130,7 @@ Returns a list of users.
   {
       "id": "f62eab5e-b0f5-47de-b60b-b3cd13d883ed",
       "name": "bobo"
-  } 
+  }
 ]
 ```
 

--- a/backend/hosting/docker/Dockerfile
+++ b/backend/hosting/docker/Dockerfile
@@ -1,0 +1,26 @@
+# This is copied from: https://v2.vuejs.org/v2/cookbook/dockerize-vuejs-app.html
+# I can take no credit for it. It's already on alpine (apk) so would be tricky to do better in the time frame
+
+FROM node:lts-alpine
+
+# install simple http server for serving static content
+RUN npm install -g http-server
+
+# make the 'app' folder the current working directory
+WORKDIR /app
+
+# copy both 'package.json' and 'package-lock.json' (if available)
+COPY backend/package*.json ./
+
+# install project dependencies
+RUN npm install
+
+# copy project files and folders to the current working directory (i.e. 'app' folder)
+COPY ./backend .
+
+# build app for production with minification
+RUN npm run build
+
+EXPOSE 8080
+EXPOSE 3030
+CMD [ "http-server", "-p", "3030", "dist" ]

--- a/backend/hosting/docker/Dockerfile
+++ b/backend/hosting/docker/Dockerfile
@@ -1,6 +1,11 @@
 # This is copied from: https://v2.vuejs.org/v2/cookbook/dockerize-vuejs-app.html
 # I can take no credit for it. It's already on alpine (apk) so would be tricky to do better in the time frame
 
+# Important Note:
+# It would be tidier to use a builder container + then move the content across to the runtime container, this
+# is definitely recommend as would prevent the image being so bulky but also prevent distributing the raw
+# source code alongside the production application. I will come back to this if I have time.
+
 FROM node:lts-alpine
 
 # install simple http server for serving static content
@@ -18,9 +23,8 @@ RUN npm install
 # copy project files and folders to the current working directory (i.e. 'app' folder)
 COPY ./backend .
 
-# build app for production with minification
-RUN npm run build
-
-EXPOSE 8080
+# expose the port for the backend service
 EXPOSE 3030
-CMD [ "http-server", "-p", "3030", "dist" ]
+
+# run the backend service
+CMD [ "node", "./dist/index.js" ]

--- a/backend/hosting/docker/Dockerfile
+++ b/backend/hosting/docker/Dockerfile
@@ -27,4 +27,4 @@ COPY ./backend .
 EXPOSE 3030
 
 # run the backend service
-CMD [ "node", "./dist/index.js" ]
+CMD [ "npm", "run", "start" ]

--- a/frontend/hosting/docker/Dockerfile
+++ b/frontend/hosting/docker/Dockerfile
@@ -1,6 +1,11 @@
 # This is copied from: https://v2.vuejs.org/v2/cookbook/dockerize-vuejs-app.html
 # I can take no credit for it. It's already on alpine (apk) so would be tricky to do better in the time frame
 
+# Important Note:
+# It would be tidier to use a builder container + then move the content across to the runtime container, this
+# is definitely recommend as would prevent the image being so bulky but also prevent distributing the raw
+# source code alongside the production application. I will come back to this if I have time.
+
 FROM node:lts-alpine
 
 # install simple http server for serving static content
@@ -21,6 +26,8 @@ COPY ./frontend .
 # build app for production with minification
 RUN npm run build
 
-EXPOSE 3030
+# expose the port for the frontend service
 EXPOSE 8080
+
+# serve the frontend service
 CMD [ "http-server", "dist" ]

--- a/frontend/hosting/docker/Dockerfile
+++ b/frontend/hosting/docker/Dockerfile
@@ -1,0 +1,26 @@
+# This is copied from: https://v2.vuejs.org/v2/cookbook/dockerize-vuejs-app.html
+# I can take no credit for it. It's already on alpine (apk) so would be tricky to do better in the time frame
+
+FROM node:lts-alpine
+
+# install simple http server for serving static content
+RUN npm install -g http-server
+
+# make the 'app' folder the current working directory
+WORKDIR /app
+
+# copy both 'package.json' and 'package-lock.json' (if available)
+COPY frontend/package*.json ./
+
+# install project dependencies
+RUN npm install
+
+# copy project files and folders to the current working directory (i.e. 'app' folder)
+COPY ./frontend .
+
+# build app for production with minification
+RUN npm run build
+
+EXPOSE 3030
+EXPOSE 8080
+CMD [ "http-server", "dist" ]

--- a/frontend/src/stores/task.ts
+++ b/frontend/src/stores/task.ts
@@ -6,7 +6,8 @@ import { defineStore } from "pinia";
 import { mande } from "mande";
 import { useUserStore } from "./user";
 
-export const taskApi = mande("/api/tasks");
+// This isn't great, it should be an environment variable but it will do for development/where BE/FE are tied together
+export const taskApi = mande("http://localhost:3030/api/tasks");
 
 // A single task; corresponds to the `Task` on the backend.
 export interface Task {

--- a/frontend/src/stores/user.ts
+++ b/frontend/src/stores/user.ts
@@ -4,7 +4,8 @@
 import { defineStore } from "pinia";
 import { mande } from "mande";
 
-export const userApi = mande("/api/users");
+// This isn't great, it should be an environment variable but it will do for development/where BE/FE are tied together
+export const userApi = mande("http://localhost:3030/api/users");
 
 // The User type. Corresponds with a `User` on the backend.
 export interface User {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     },
   },
   server: {
+    host: true,
     proxy: {
       "/api": "http://localhost:3030",
     },

--- a/local-development/development.env
+++ b/local-development/development.env
@@ -1,0 +1,3 @@
+# These can be used to develop future features under specific feature flags/variables or similar
+EXAMPLE_ENV_VAR_FE: "example-frontend-var"
+EXAMPLE_ENV_VAR_BE: "example-backend-var"

--- a/local-development/docker-compose-be.yml
+++ b/local-development/docker-compose-be.yml
@@ -1,0 +1,9 @@
+version: "3"
+services:
+  si-assessment-ie3-backend:
+    image: si-assessment-ie3-backend:latest
+    ports:
+      - "3030:3030"
+    platform: linux/amd64 # To accommodate for cross-platform builds (e.g. M series mac)
+    environment:
+      EXAMPLE_ENV_VAR_BE: ${EXAMPLE_ENV_VAR_BE}

--- a/local-development/docker-compose-fe.yml
+++ b/local-development/docker-compose-fe.yml
@@ -1,0 +1,9 @@
+version: "3"
+services:
+  si-assessment-ie3-frontend:
+    image: si-assessment-ie3-frontend:latest
+    ports:
+      - "8080:8080"
+    platform: linux/amd64 # To accommodate for cross-platform builds (e.g. M series mac)
+    environment:
+      EXAMPLE_ENV_VAR_FE: ${EXAMPLE_ENV_VAR_FE}

--- a/local-development/docker-compose-stack.yml
+++ b/local-development/docker-compose-stack.yml
@@ -1,19 +1,19 @@
 version: "3"
 services:
-  #si-assessment-ie3-frontend:
-  #  image: si-assessment-ie3-frontend:latest
-  #  ports:
-  #    - "8080:8080"
-  #  platform: linux/amd64 # To accommodate for cross-platform builds (e.g. M series mac)
-  #  environment:
-  #    EXAMPLE_ENV_VAR_FE: ${EXAMPLE_ENV_VAR_FE}
+  si-assessment-ie3-frontend:
+    image: si-assessment-ie3-frontend:latest
+    ports:
+      - "8080:8080"
+    platform: linux/amd64 # To accommodate for cross-platform builds (e.g. M series mac)
+    environment:
+      EXAMPLE_ENV_VAR_FE: ${EXAMPLE_ENV_VAR_FE}
 
   si-assessment-ie3-backend:
     image: si-assessment-ie3-backend:latest
     ports:
       - "3030:3030"
     platform: linux/amd64 # To accommodate for cross-platform builds (e.g. M series mac)
-    #links:
-    #  - si-assessment-ie3-frontend
+    links:
+      - si-assessment-ie3-frontend
     environment:
       EXAMPLE_ENV_VAR_BE: ${EXAMPLE_ENV_VAR_BE}

--- a/local-development/docker-compose-stack.yml
+++ b/local-development/docker-compose-stack.yml
@@ -1,0 +1,19 @@
+version: "3"
+services:
+  #si-assessment-ie3-frontend:
+  #  image: si-assessment-ie3-frontend:latest
+  #  ports:
+  #    - "8080:8080"
+  #  platform: linux/amd64 # To accommodate for cross-platform builds (e.g. M series mac)
+  #  environment:
+  #    EXAMPLE_ENV_VAR_FE: ${EXAMPLE_ENV_VAR_FE}
+
+  si-assessment-ie3-backend:
+    image: si-assessment-ie3-backend:latest
+    ports:
+      - "3030:3030"
+    platform: linux/amd64 # To accommodate for cross-platform builds (e.g. M series mac)
+    #links:
+    #  - si-assessment-ie3-frontend
+    environment:
+      EXAMPLE_ENV_VAR_BE: ${EXAMPLE_ENV_VAR_BE}


### PR DESCRIPTION
2. CI (Continuous Integration): Build, Test, and Release flow:
   - [X] Build + Containerize the applications, with local deployment validation
         - Added a hosting/docker/Dockerfile into each application path and added a Makefile that allows quick validation of build, e.g. `make build-fe`. Additionally, `make deploy` immediately deploys the two tags of si-assessment-ie3-backend:latest and si-assessment-ie3-frontned:latest, which would be available locally if `make build-fe` / `make build-be` were used. The `local-development/docker-compose-stack.yml` file can be manipulated accordingly if the developer or tester wanted to check two different versions of the services together. On `make deploy` the frontend service can be reached on x and the backend service can be reached on y. Also individually added a `make validate-be` and `make validate-fe` function to quickly validate the basic http integrity of the application variant. This ensures that no code changes makes it very far without maintaining application integrity while the unit-tests and other code-validation still pass. This should stop non-compatible changes in the origin baseimage adversely affecting the compatibility with the code at a basic level.
         - Added all the above checks in a basic CI build pipeline
         - `frontend/src/stores/task.ts` and `frontend/src/stores/user.ts` were adjusted (poorly) to allow the backend and frontend to talk together in a docker-based environment. This could be refactored later to be an environment variable or similar.
         - https://github.com/johnrwatson/si-assessment-ie3/pull/4
   - [X] Initiate tests in CI
     - [X] Application Integrity: -
           - https://github.com/johnrwatson/si-assessment-ie3/pull/4