### PR TITLE
chore: added test matrixes for fe and be

### DIFF
--- a/.github/workflows/core-build.yml
+++ b/.github/workflows/core-build.yml
@@ -59,6 +59,23 @@ jobs:
         run: make build-fe
       - name: Make validate FE (checks the application's integrity at a basic level)
         run: make validate-fe
+      - name: SBOM generation
+        run: |
+          export IMAGE_NAME="si-assessment-ie3-frontend:latest"
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+          echo "Info: Start of SBOM for container image ${IMAGE_NAME}"
+          /usr/local/bin/syft ${IMAGE_NAME} --scope all-layers
+          echo "Info: End of SBOM for container image ${IMAGE_NAME}"
+      # Couldn't quite get this to work in the timeframe but can easily be added after
+      #- name: Trivy Scan
+      #  run: |
+      #    export IMAGE_NAME="si-assessment-ie3-frontend:latest"
+      #    apt update && apt install wget
+      #    wget https://github.com/aquasecurity/trivy/releases/download/v0.43.1/trivy_0.43.1_Linux-64bit.deb
+      #    sudo apt install ./trivy_0.43.1_Linux-ARM64.deb
+      #    echo "Info: Start of Trivy Scan for container image ${IMAGE_NAME}"
+      #    trivy --no-progress --severity HIGH,CRITICAL ${IMAGE_NAME}
+      #    echo "Info: End of Trivy Scan for container image ${IMAGE_NAME}"
 
   build-be:
     runs-on: ubuntu-latest
@@ -68,6 +85,23 @@ jobs:
         run: make build-be
       - name: Make validate BE (checks the application's integrity at a basic level)
         run: make validate-be
+      - name: SBOM generation
+        run: |
+          export IMAGE_NAME="si-assessment-ie3-backend:latest"
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+          echo "Info: Start of SBOM for container image ${IMAGE_NAME}"
+          /usr/local/bin/syft ${IMAGE_NAME} --scope all-layers
+          echo "Info: End of SBOM for container image ${IMAGE_NAME}"
+      # Couldn't quite get this to work in the timeframe but can easily be added after
+      #- name: Trivy Scan
+      #  run: |
+      #    export IMAGE_NAME="si-assessment-ie3-backend:latest"
+      #    apt update && apt install wget
+      #    wget https://github.com/aquasecurity/trivy/releases/download/v0.43.1/trivy_0.43.1_Linux-64bit.deb
+      #    sudo apt install ./trivy_0.43.1_Linux-ARM64.deb
+      #    echo "Info: Start of Trivy Scan for container image ${IMAGE_NAME}"
+      #    trivy --no-progress --severity HIGH,CRITICAL ${IMAGE_NAME}
+      #    echo "Info: End of Trivy Scan for container image ${IMAGE_NAME}"
 
   # This will be developed out to include the deployment of the images
   deploy-apps:

--- a/.github/workflows/core-build.yml
+++ b/.github/workflows/core-build.yml
@@ -8,7 +8,49 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env: # environment variables (available in any part of the action)
+  NODE_VERSION: 20
+
 jobs:
+
+  test-matrix-fe: # At this stage likely doesn't need to be a matrix type
+    strategy: # due to 1 test. Using matrix so additional can be added in later easily.
+      matrix:
+        test: [lint]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install NodeJS
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Code Checkout
+        uses: actions/checkout@v2
+      - name: Install Dependencies
+        working-directory: frontend
+        run: npm ci
+      - name: Code ${{ matrix.test }}
+        working-directory: frontend
+        run: npm run ${{ matrix.test }}
+
+  test-matrix-be:
+    strategy:
+      matrix:
+        test: [lint, type-check, format]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install NodeJS
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Code Checkout
+        uses: actions/checkout@v2
+      - name: Install Dependencies
+        working-directory: backend
+        run: npm ci
+      - name: Code ${{ matrix.test }}
+        working-directory: backend
+        run: npm run ${{ matrix.test }}
+
   build-fe:
     runs-on: ubuntu-latest
     steps:
@@ -29,7 +71,7 @@ jobs:
 
   # This will be developed out to include the deployment of the images
   deploy-apps:
-    needs: [build-fe, build-be]
+    needs: [test-matrix-be, test-matrix-fe, build-fe, build-be]
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -34,13 +34,14 @@ Hopefully this makes it easier to follow the path I have taken. I have also outl
          - `frontend/src/stores/task.ts` and `frontend/src/stores/user.ts` were adjusted (poorly) to allow the backend and frontend to talk together in a docker-based environment. This could be refactored later to be an environment variable or similar.
          - https://github.com/johnrwatson/si-assessment-ie3/pull/4
    - [X] Initiate tests in CI
+     - All code-level tests added as a matrix to save as much time as possible in CI/feedback. In reality developer/tester time is magnitudes more important that CI cost, so this is the preferable route in most situations. Added an SBOM Generation to the tail end of the build workflow. This isn't ideal as it's a bit untidy and slows the critical path (with the build already being the slowest task) but in total it's only ~1 minute which is pretty quick. I couldn't quite get the Trivy scan to work in the pipeline within the time constraints but the example workflow provided (commented out) is very close, just an envrionment issue/diff between local:remote.
      - [X] Application Integrity: -
            - https://github.com/johnrwatson/si-assessment-ie3/pull/4
      - [X] Lint
            - https://github.com/johnrwatson/si-assessment-ie3/pull/5
      - [X] Unit Test
            - https://github.com/johnrwatson/si-assessment-ie3/pull/5
-     - [X] Security Scan
+     - [] Security Scan
            - https://github.com/johnrwatson/si-assessment-ie3/pull/5
      - [X] SBOM Generation
            - https://github.com/johnrwatson/si-assessment-ie3/pull/5

--- a/README.md
+++ b/README.md
@@ -36,10 +36,14 @@ Hopefully this makes it easier to follow the path I have taken. I have also outl
    - [X] Initiate tests in CI
      - [X] Application Integrity: -
            - https://github.com/johnrwatson/si-assessment-ie3/pull/4
-     - [ ] Lint
-     - [ ] Unit Test
-     - [ ] Security Scan
-     - [ ] SBOM Generation
+     - [X] Lint
+           - https://github.com/johnrwatson/si-assessment-ie3/pull/5
+     - [X] Unit Test
+           - https://github.com/johnrwatson/si-assessment-ie3/pull/5
+     - [X] Security Scan
+           - https://github.com/johnrwatson/si-assessment-ie3/pull/5
+     - [X] SBOM Generation
+           - https://github.com/johnrwatson/si-assessment-ie3/pull/5
    - [ ] Initiate release flow to an Artifact Registry
    - [ ] Register the service with the Artifact Database
 


### PR DESCRIPTION
   - [X] Initiate tests in CI
     - All code-level tests added as a matrix to save as much time as possible in CI/feedback. In reality developer/tester time is magnitudes more important that CI cost, so this is the preferable route in most situations. Added an SBOM Generation to the tail end of the build workflow. This isn't ideal as it's a bit untidy and slows the critical path (with the build already being the slowest task) but in total it's only ~1 minute which is pretty quick. I couldn't quite get the Trivy scan to work in the pipeline within the time constraints but the example workflow provided (commented out) is very close, just an envrionment issue/diff between local:remote.
     - [X] Application Integrity: -
           - https://github.com/johnrwatson/si-assessment-ie3/pull/4
     - [X] Lint
           - https://github.com/johnrwatson/si-assessment-ie3/pull/5
     - [X] Unit Test
           - https://github.com/johnrwatson/si-assessment-ie3/pull/5
     - [] Security Scan
           - https://github.com/johnrwatson/si-assessment-ie3/pull/5
     - [X] SBOM Generation
           - https://github.com/johnrwatson/si-assessment-ie3/pull/5
           
NB: Force rebased over the debugging commits while trying to get the Security/Trivy scan in.