### PR TITLE
Feat/add development env

### DIFF
--- a/.github/healthchecker.sh
+++ b/.github/healthchecker.sh
@@ -53,8 +53,8 @@ main() {
 
 }
 
-export SECS_TO_CHECK=$1  # < 60 (minutes) >
-export AUTH_HEADERS=$2   # < automation-user:automation-user >
-export URLS="${@:3}"     # < List of URLs >
+SECS_TO_CHECK=$1  # < 60 (minutes) >
+AUTH_HEADERS=$2   # < automation-user:automation-user >
+URLS="${@:3}"     # < List of URLs >
 
-main $SECS_TO_CHECK $URLS
+main

--- a/.github/servicechecker.sh
+++ b/.github/servicechecker.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Helper function to runs a polling-based waiter to check for when a service has resolved it's IP address in Kubernetes. Usually
+# takes about a minute. Can be re-used for any cluster, namespace or service, it just assumed the cluster is already authenticated to with kubectl.
+
+# Where:
+# $1: seconds to run the check for
+# $2: namespace
+# $3: servicename
+
+service_healthcheck() {
+
+    LINK_HTTP_CODE=$(kubectl -n si-assessment-ie3 get svc -o jsonpath="{.items[0].status.loadBalancer.ingress[0].ip}")
+    echo "INFO: $LINK_HTTP_CODE found for $SERVICE_NAME"
+
+    if [ "$LINK_HTTP_CODE" == "<pending>" ]
+    then
+        echo "1" >> /tmp/url-responses
+    else
+        echo "0" >> /tmp/url-responses
+    fi
+
+    FAILURE_NUMBER=$(cat /tmp/url-responses | { grep "1" | wc -l | xargs || true; } )
+    echo "INFO: FAILURE_NUMBER found to be $FAILURE_NUMBER"
+
+    rm /tmp/url-responses
+
+    [[ $FAILURE_NUMBER == 0 ]] && echo "SUCCESS: All services returned ips successfully, listed below (note EXTERNAL-IP key)"
+    kubectl -n $NAMESPACE get svc
+    exit 0
+}
+
+main() {
+
+    echo "INFO: Running service checks for $SECS_TO_CHECK seconds."
+
+    COUNT=0
+
+    while [ "$COUNT" -lt $SECS_TO_CHECK ]
+    do
+        service_healthcheck
+        COUNT=$((COUNT+1))
+        sleep 1
+    done
+
+    echo "ERROR: Endpoints did not return their service IP"
+    exit 1
+
+}
+
+export SECS_TO_CHECK=$1        # < 60 (minutes) >
+export NAMESPACE=$2            # < any-namespace >
+export SERVICE_NAME="${@:3}"  # < name-of-service to check >
+
+# $1: seconds to run the check for
+# $2: namespace
+# $3: servicename
+
+main

--- a/.github/workflows/core-build.yml
+++ b/.github/workflows/core-build.yml
@@ -2,9 +2,13 @@
 
 name: core-build
 
+# On push of a tag or open pull requests to main
+# Always promote the version into the artifact registry
+# But only deploy if it's a tag
 on:
   push:
-    branches: [ "main" ]
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
   pull_request:
     branches: [ "main" ]
 
@@ -14,7 +18,7 @@ env: # environment variables (available in any part of the action)
 jobs:
 
   test-matrix-fe: # At this stage likely doesn't need to be a matrix type
-    strategy: # due to 1 test. Using matrix so additional can be added in later easily.
+    strategy:     # due to 1 test. Using matrix so additional can be added in later easily.
       matrix:
         test: [lint]
     runs-on: ubuntu-latest
@@ -76,6 +80,22 @@ jobs:
       #    echo "Info: Start of Trivy Scan for container image ${IMAGE_NAME}"
       #    trivy --no-progress --severity HIGH,CRITICAL ${IMAGE_NAME}
       #    echo "Info: End of Trivy Scan for container image ${IMAGE_NAME}"
+      - name: Install GCP CLI
+        run: curl https://sdk.cloud.google.com | bash
+      - name: Docker Push the Artifact into the Registry
+        run: |
+          echo "$GOOGLE_CREDENTIALS" > ./google_sa_key.json
+          gcloud auth activate-service-account --key-file=./google_sa_key.json
+          docker tag si-assessment-ie3-frontend:latest us-west1-docker.pkg.dev/artifact-flow/si-assessment-ie3-frontend/si-assessment-ie3-frontend:$GITHUB_SHA
+          gcloud auth configure-docker us-west1-docker.pkg.dev
+          docker push us-west1-docker.pkg.dev/artifact-flow/si-assessment-ie3-frontend/si-assessment-ie3-frontend:$GITHUB_SHA
+        env:
+          GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+      - name: Promote Latest Tag from Commit Build
+        if: startsWith(github.event.ref, 'refs/tags/')
+        run: |
+          docker tag us-west1-docker.pkg.dev/artifact-flow/si-assessment-ie3-frontend/si-assessment-ie3-frontend:$GITHUB_SHA us-west1-docker.pkg.dev/artifact-flow/si-assessment-ie3-frontend/si-assessment-ie3-backend:${GITHUB_REF#refs/*/}
+          docker push us-west1-docker.pkg.dev/artifact-flow/si-assessment-ie3-frontend/si-assessment-ie3-frontend:${GITHUB_REF#refs/*/}
 
   build-be:
     runs-on: ubuntu-latest
@@ -102,12 +122,46 @@ jobs:
       #    echo "Info: Start of Trivy Scan for container image ${IMAGE_NAME}"
       #    trivy --no-progress --severity HIGH,CRITICAL ${IMAGE_NAME}
       #    echo "Info: End of Trivy Scan for container image ${IMAGE_NAME}"
+      - name: Install GCP CLI
+        run: curl https://sdk.cloud.google.com | bash
+      - name: Docker Push the Artifact into the Registry
+        run: |
+          echo "$GOOGLE_CREDENTIALS" > ./google_sa_key.json
+          gcloud auth activate-service-account --key-file=./google_sa_key.json
+          docker tag si-assessment-ie3-backend:latest us-west1-docker.pkg.dev/artifact-flow/si-assessment-ie3-backend/si-assessment-ie3-backend:$GITHUB_SHA
+          gcloud auth configure-docker us-west1-docker.pkg.dev
+          docker push us-west1-docker.pkg.dev/artifact-flow/si-assessment-ie3-backend/si-assessment-ie3-backend:$GITHUB_SHA
+        env:
+          GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+      - name: Promote Latest Tag from Commit Build
+        if: startsWith(github.event.ref, 'refs/tags/')
+        run: |
+          docker tag us-west1-docker.pkg.dev/artifact-flow/si-assessment-ie3-backend/si-assessment-ie3-backend:$GITHUB_SHA us-west1-docker.pkg.dev/artifact-flow/si-assessment-ie3-backend/si-assessment-ie3-backend:${GITHUB_REF#refs/*/}
+          docker push us-west1-docker.pkg.dev/artifact-flow/si-assessment-ie3-backend/si-assessment-ie3-backend:${GITHUB_REF#refs/*/}
 
-  # This will be developed out to include the deployment of the images
+  # Deploying the images into the development environment if on tag
   deploy-apps:
+    if: startsWith(github.event.ref, 'refs/tags/')
     needs: [test-matrix-be, test-matrix-fe, build-fe, build-be]
     runs-on: ubuntu-latest
-
     steps:
-      - name: Use Images Here
-        run: echo "Using images from previous build step here"
+      - name: Kubernetes Install
+        run: curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x ./kubectl && mv ./kubectl /usr/local/bin/kubectl
+      - name: Setup Gcloud Repositories for authentication plugin
+        run: |
+          sudo apt-get update
+          sudo apt-get install apt-transport-https ca-certificates gnupg curl
+          echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+          curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+          sudo apt-get update
+          sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
+      - name: Kubernetes Deploy
+        run: |
+          echo "Info: Deploying ${GITHUB_REF#refs/*/} into development environment"
+          gcloud container clusters get-credentials si-assessment-ie3	--region us-west1 --project artifact-flow
+          sed -i "s/IMAGE_VERSION/${GITHUB_REF#refs/*/}/g" ./hosting/kubernetes/development.yml # Inject the version of the tag
+          kubectl delete -f ./hosting/kubernetes/development.yml
+          kubectl apply -f ./hosting/kubernetes/development.yml
+          .github/servicechecker.sh 15 si-assessment-ie3 si-assessment-ie3
+        env:
+          USE_GKE_GCLOUD_AUTH_PLUGIN: True

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build-be:
 	docker build --platform linux/amd64 -f ./backend/hosting/docker/Dockerfile -t si-assessment-ie3-backend:latest .
 
 build-fe:
-	docker build --platform linux/amd64 -f ./frontend/hosting/docker/Dockerfile -t si-assessment-ie3-frontend:latest .
+	docker build --platform linux/amd64 --build-arg CI=${CI} -f ./frontend/hosting/docker/Dockerfile -t si-assessment-ie3-frontend:latest .
 
 validate-be:
 	docker compose -f ./local-development/docker-compose-be.yml --env-file ./local-development/development.env up -d

--- a/frontend/hosting/docker/Dockerfile
+++ b/frontend/hosting/docker/Dockerfile
@@ -8,6 +8,9 @@
 
 FROM node:lts-alpine
 
+# Set a build arg to determine whether local or CI build
+ARG CI
+
 # install simple http server for serving static content
 RUN npm install -g http-server
 
@@ -23,8 +26,8 @@ RUN npm install
 # copy project files and folders to the current working directory (i.e. 'app' folder)
 COPY ./frontend .
 
-# build app for production with minification
-RUN npm run build
+# build app for production with minification if in CI, otherwise make it a local build
+RUN if [ "$CI" = "true" ]; then NODE_ENV="production" npm run build; else NODE_ENV="development" npm run build-development; fi
 
 # expose the port for the frontend service
 EXPOSE 8080

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@headlessui/vue": "^1.6.4",
         "@heroicons/vue": "^1.0.6",
+        "isomorphic-fetch": "^3.0.0",
         "mande": "^2.0.2",
         "pinia": "^2.0.14",
         "vue": "^3.2.36",
@@ -19,7 +20,8 @@
         "@rushstack/eslint-patch": "^1.1.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/typography": "^0.5.2",
-        "@types/node": "^16.11.36",
+        "@types/isomorphic-fetch": "^0.0.36",
+        "@types/node": "^16.18.38",
         "@vitejs/plugin-vue": "^2.3.3",
         "@vue/eslint-config-prettier": "^7.0.0",
         "@vue/eslint-config-typescript": "^10.0.0",
@@ -173,6 +175,12 @@
         "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || insiders"
       }
     },
+    "node_modules/@types/isomorphic-fetch": {
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.36.tgz",
+      "integrity": "sha512-ulw4d+vW1HKn4oErSmNN2HYEcHGq0N1C5exlrMM0CRqX1UUpFhGb5lwiom5j9KN3LBJJDLRmYIZz1ghm7FIzZw==",
+      "dev": true
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -180,9 +188,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.11.38",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.38.tgz",
-      "integrity": "sha512-hjO/0K140An3GWDw2HJfq7gko3wWeznbjXgg+rzPdVzhe198hp4x2i1dgveAOEiFKd8sOilAxzoSJiVv5P/CUg==",
+      "version": "16.18.38",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.38.tgz",
+      "integrity": "sha512-6sfo1qTulpVbkxECP+AVrHV9OoJqhzCsfTNp5NIG+enM4HyM3HvZCO798WShIXBN0+QtDIcutJCjsVYnQP5rIQ==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2399,6 +2407,15 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -2601,6 +2618,25 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.5",
@@ -3658,6 +3694,11 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -3886,6 +3927,25 @@
         "typescript": "*"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4061,6 +4121,12 @@
         "lodash.merge": "^4.6.2"
       }
     },
+    "@types/isomorphic-fetch": {
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.36.tgz",
+      "integrity": "sha512-ulw4d+vW1HKn4oErSmNN2HYEcHGq0N1C5exlrMM0CRqX1UUpFhGb5lwiom5j9KN3LBJJDLRmYIZz1ghm7FIzZw==",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -4068,9 +4134,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.38",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.38.tgz",
-      "integrity": "sha512-hjO/0K140An3GWDw2HJfq7gko3wWeznbjXgg+rzPdVzhe198hp4x2i1dgveAOEiFKd8sOilAxzoSJiVv5P/CUg==",
+      "version": "16.18.38",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.38.tgz",
+      "integrity": "sha512-6sfo1qTulpVbkxECP+AVrHV9OoJqhzCsfTNp5NIG+enM4HyM3HvZCO798WShIXBN0+QtDIcutJCjsVYnQP5rIQ==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -5567,6 +5633,15 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "requires": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
     "js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -5733,6 +5808,14 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "node-releases": {
       "version": "2.0.5",
@@ -6439,6 +6522,11 @@
         "is-number": "^7.0.0"
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -6591,6 +6679,25 @@
       "dev": true,
       "requires": {
         "@volar/vue-typescript": "0.35.2"
+      }
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "which": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "dev": "vite",
     "build": "run-p type-check build-only",
+    "build-development": "vite build --mode development",
     "preview": "vite preview --port 4173",
     "build-only": "vite build",
     "type-check": "vue-tsc --noEmit",
@@ -12,6 +13,7 @@
   "dependencies": {
     "@headlessui/vue": "^1.6.4",
     "@heroicons/vue": "^1.0.6",
+    "isomorphic-fetch": "^3.0.0",
     "mande": "^2.0.2",
     "pinia": "^2.0.14",
     "vue": "^3.2.36",
@@ -21,7 +23,8 @@
     "@rushstack/eslint-patch": "^1.1.0",
     "@tailwindcss/forms": "^0.5.2",
     "@tailwindcss/typography": "^0.5.2",
-    "@types/node": "^16.11.36",
+    "@types/isomorphic-fetch": "^0.0.36",
+    "@types/node": "^16.18.38",
     "@vitejs/plugin-vue": "^2.3.3",
     "@vue/eslint-config-prettier": "^7.0.0",
     "@vue/eslint-config-typescript": "^10.0.0",

--- a/frontend/src/stores/task.ts
+++ b/frontend/src/stores/task.ts
@@ -5,9 +5,11 @@
 import { defineStore } from "pinia";
 import { mande } from "mande";
 import { useUserStore } from "./user";
+import fetch from "isomorphic-fetch";
 
-// This isn't great, it should be an environment variable but it will do for development/where BE/FE are tied together
-export const taskApi = mande("http://localhost:3030/api/tasks");
+// In a production situation the dns name hosting the FE would be injected here instead of a reserved static ip
+export const BASE_URL = process.env.NODE_ENV === "production" ? "http://35.247.107.51:3030" : "http://localhost:3030";
+export const taskApi = mande(BASE_URL + "/api/tasks", {}, fetch);
 
 // A single task; corresponds to the `Task` on the backend.
 export interface Task {

--- a/frontend/src/stores/user.ts
+++ b/frontend/src/stores/user.ts
@@ -3,9 +3,11 @@
 
 import { defineStore } from "pinia";
 import { mande } from "mande";
+import fetch from "isomorphic-fetch";
 
-// This isn't great, it should be an environment variable but it will do for development/where BE/FE are tied together
-export const userApi = mande("http://localhost:3030/api/users");
+// In a production situation the dns name hosting the FE would be injected here instead of a reserved static ip
+export const BASE_URL = process.env.NODE_ENV === "production" ? "http://35.247.107.51:3030" : "http://localhost:3030";
+export const userApi = mande(BASE_URL + "/api/users", {}, fetch);
 
 // The User type. Corresponds with a `User` on the backend.
 export interface User {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -7,6 +7,9 @@
       "@/*": ["./src/*"]
     },
     "allowJs": true,
+    "lib": ["esnext", "dom", "dom.iterable", "scripthost", "webworker"],
+    "types": ["node"],
+    "noImplicitAny": false
   },
   "references": [
     {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,10 +11,4 @@ export default defineConfig({
       "@": fileURLToPath(new URL("./src", import.meta.url)),
     },
   },
-  server: {
-    host: true,
-    proxy: {
-      "/api": "http://localhost:3030",
-    },
-  },
 });

--- a/hosting/kubernetes/development.yml
+++ b/hosting/kubernetes/development.yml
@@ -1,0 +1,86 @@
+# Commented out sections so the apply and delete doesn't nuke the supporting resources, included here
+# just so reviewer has full transparency.
+# ----------------------------------------------------------------------------------------------------
+
+# ---
+# apiVersion: v1
+# kind: Namespace
+# metadata:
+#   name: si-assessment-ie3
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: si-assessment-ie3
+  namespace: si-assessment-ie3
+spec:
+  selector:
+    matchLabels:
+      app: si-assessment-ie3
+      department: si-assessment-ie3
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: si-assessment-ie3
+        department: si-assessment-ie3
+    spec:
+      containers:
+        # Using a multi-container pod as the two applications are directly dependent on eachother.
+        # In production you would likely split these to be two separate services with their own
+        # networking routes/services etc.
+        - name: si-assessment-ie3-backend
+          image: us-west1-docker.pkg.dev/artifact-flow/si-assessment-ie3-backend/si-assessment-ie3-backend:IMAGE_VERSION
+          imagePullPolicy: Always
+          readinessProbe:
+            httpGet:
+              path: /api/users
+              port: 3030
+            failureThreshold: 1
+            periodSeconds: 10
+          ports:
+          - containerPort: 3030
+          resources:
+            requests:
+              memory: "1024Mi"
+              cpu: "500m"
+        - name: si-assessment-ie3-frontend
+          image: us-west1-docker.pkg.dev/artifact-flow/si-assessment-ie3-frontend/si-assessment-ie3-frontend:IMAGE_VERSION
+          imagePullPolicy: Always
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            failureThreshold: 1
+            periodSeconds: 10
+          ports:
+          - containerPort: 8080
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "125m"
+
+# ---
+# apiVersion: v1
+# kind: Service
+# metadata:
+#   name: si-assessment-ie3
+#   namespace: si-assessment-ie3
+#   labels:
+#     app: si-assessment-ie3
+#     department: si-assessment-ie3
+# spec:
+#   type: LoadBalancer
+#   selector:
+#     app: si-assessment-ie3
+#     department: si-assessment-ie3
+#   ports:
+#     - protocol: TCP
+#       name: frontend
+#       port: 8080
+#       targetPort: 8080
+#     - protocol: TCP
+#       name: backend
+#       port: 3030
+#       targetPort: 3030

--- a/local-development/docker-compose-stack.yml
+++ b/local-development/docker-compose-stack.yml
@@ -5,8 +5,6 @@ services:
     ports:
       - "8080:8080"
     platform: linux/amd64 # To accommodate for cross-platform builds (e.g. M series mac)
-    environment:
-      EXAMPLE_ENV_VAR_FE: ${EXAMPLE_ENV_VAR_FE}
 
   si-assessment-ie3-backend:
     image: si-assessment-ie3-backend:latest
@@ -15,5 +13,3 @@ services:
     platform: linux/amd64 # To accommodate for cross-platform builds (e.g. M series mac)
     links:
       - si-assessment-ie3-frontend
-    environment:
-      EXAMPLE_ENV_VAR_BE: ${EXAMPLE_ENV_VAR_BE}


### PR DESCRIPTION
- On merge to main, it deploys the latest tags into a GCR repository (one for frontend, one for backend). This is not ideal as it's using mutable artifacts/tags but for development it means that the environment is always a reflection of what has been merged to main (assuming that the ci-cd passes). I was a bit pressed for time, but I would have loved to spend time making sure that the version reflected in the environment is a uniquely identifiable artifact that has it's own version that matches the git tag.

- Added a Google Kubernetes Autopilot cluster with a basic kubernetes manifest to deploy into the development environment



